### PR TITLE
adding ssl support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info
 *.pyc
+.idea
 dist/
 build/

--- a/bottle_websocket/server.py
+++ b/bottle_websocket/server.py
@@ -7,7 +7,7 @@ from geventwebsocket.logging import create_logger
 
 class GeventWebSocketServer(ServerAdapter):
     def run(self, handler):
-        server = pywsgi.WSGIServer((self.host, self.port), handler, handler_class=WebSocketHandler)
+        server = pywsgi.WSGIServer((self.host, self.port), handler, handler_class=WebSocketHandler, **self.options)
 
         if not self.quiet:
             server.logger = create_logger('geventwebsocket.logging')


### PR DESCRIPTION
In reference to Issue #12
WSGIServer has SSL support inbuilt. Just need to add proper parameters.
Generate private key and certificate (can be self-signed) first. Then use as below - 

```
ssldict = {'keyfile': 'keys/privkey.pem', 'certfile': 'keys/cacert.pem'}

run(host='0.0.0.0', port=8080, server=GeventWebSocketServer, **ssldict)
```